### PR TITLE
Update for RF tweakscale support

### DIFF
--- a/GameData/TweakScale/ScaleExponents.cfg
+++ b/GameData/TweakScale/ScaleExponents.cfg
@@ -146,6 +146,7 @@ TWEAKSCALEEXPONENTS
     maxFuelFlow = 2.5
     maxThrust = 2.5
     //heatProduction = 0.85 // ignored by KSP
+    -ignore = ModuleEngineConfigs
 }
 
 TWEAKSCALEEXPONENTS
@@ -155,12 +156,14 @@ TWEAKSCALEEXPONENTS
     maxFuelFlow = 2.5
     maxThrust = 2.5
     //heatProduction = 0.85 // ignored by KSP
+    -ignore = ModuleEngineConfigs
 }
 
 TWEAKSCALEEXPONENTS
 {
     name = ModuleRCS
     thrusterPower = 2.5
+    -ignore = ModuleEngineConfigs
 }
 
 TWEAKSCALEEXPONENTS


### PR DESCRIPTION
no scaling of engines/RCS if ModuleEngineConfigs is present (it will handle it).

@pellinor0 : How should we handle mass? MEC will scale the mass itself if origMass is set, we need that not to collide with tweakscale.