### PR TITLE
Added Missing Aero Parts and a Fuel Adapter

### DIFF
--- a/GameData/TweakScale/patches/Squad_TweakScale.cfg
+++ b/GameData/TweakScale/patches/Squad_TweakScale.cfg
@@ -885,7 +885,30 @@
         type = free_square
     }
 }
+@PART[delta_small] // Small Delta Wing
+{
+    %MODULE[TweakScale]
+    {
+        type = free_square
+    }
+}
 @PART[noseCone] // Aerodynamic Nose Cone
+{
+    %MODULE[TweakScale]
+    {
+        type = stack_square
+        defaultScale = 1.25
+    }
+}
+@PART[pointyNoseConeA] // Pointy Nose Cone A
+{
+    %MODULE[TweakScale]
+    {
+        type = stack_square
+        defaultScale = 1.25
+    }
+}
+@PART[pointyNoseConeB] // Pointy Nose Cone B
 {
     %MODULE[TweakScale]
     {
@@ -1407,6 +1430,14 @@
         defaultScale = 1.25
     }
 }
+@PART[MK1IntakeFuselage] // Mk1 Fuselage Intake
+{
+    %MODULE[TweakScale]
+    {
+        type = stack_square
+        defaultScale = 1.25
+    }
+}
 
 
 
@@ -1681,6 +1712,14 @@
         defaultScale = 3.75
     }
 }
+@PART[adapterSize2-Mk2]
+{
+    %MODULE[TweakScale]
+    {
+        type = stack
+        defaultScale = 2.5
+    }
+}
 @PART[adapterSize2-Size1]
 {
     %MODULE[TweakScale]
@@ -1695,5 +1734,27 @@
     {
         type = stack
         defaultScale = 2.5
+    }
+}
+
+@PART[structuralWing4] // Structural Wing Type D
+{
+    %MODULE[TweakScale]
+    {
+        type = free_square
+    }
+}
+@PART[wingConnector5] // Wing Connector Type E
+{
+    %MODULE[TweakScale]
+    {
+        type = free_square
+    }
+}
+@PART[elevon5] // Elevon5
+{
+    %MODULE[TweakScale]
+    {
+        type = free_square
     }
 }


### PR DESCRIPTION
Added parts:
2.5 to Mk2 Adapter
Advanced Nose Cone Type A & B
Mk1 Fuselage Intake
Small Delta Wing
Elevon 5
Structural Wing Type D
Wing Connector Type E

structuralWing4, wingConnector5, and elevon5 were missed when the lower
versions of each were added to spacePlanePlus.