### PR TITLE
Update KerbalStuff link to Spacedock

### DIFF
--- a/GameData/TweakScale/TweakScale.version
+++ b/GameData/TweakScale/TweakScale.version
@@ -1,7 +1,7 @@
 {
      "NAME":"TweakScale",
      "URL":"https://github.com/pellinor0/TweakScale/blob/master/GameData/TweakScale/TweakScale.version",
-     "DOWNLOAD":"https://kerbalstuff.com/mod/344/TweakScale%20-%20Rescale%20Everything!/download/",
+     "DOWNLOAD":"https://spacedock.info/mod/127/TweakScale/download/",
      "GITHUB":{
          "USERNAME":"Pellinor",
          "REPOSITORY":"TweakScale",


### PR DESCRIPTION
Changes KSP-AVC's download to send you to SpaceDock, instead of the deprecated KerbalStuff